### PR TITLE
Fix edge case with commentEnd tokenization

### DIFF
--- a/lib/tokenize-comment.js
+++ b/lib/tokenize-comment.js
@@ -13,7 +13,7 @@ let newline    = '\n'.charCodeAt(0),
     openCurly  = '{'.charCodeAt(0),
     closeCurly = '}'.charCodeAt(0),
     asterisk   = '*'.charCodeAt(0),
-    wordEnd    = /[ \n\t\r\(\)\{\},:;@!'"\\]|\/(?=\*)|#(?={)/g;
+    wordEnd    = /[ \n\t\r\(\)\{\},:;@!'"\\]|\*(?=\/)|#(?={)/g;
 
 export default function tokenize(input, l, p) {
     let tokens = [];

--- a/test/comment.js
+++ b/test/comment.js
@@ -69,4 +69,17 @@ describe('Comment', function() {
             scss.tokenize(fixture('docblock-comment.scss'))
         );
     });
+
+    it('should tokenize a comment that does not have a space before the end', function() {
+        assert.deepEqual(
+            [
+                ['startComment', '/*', 1, 2],
+                ['word', 'my', 1, 3, 1, 4],
+                ['space', ' '],
+                ['word', 'comment', 1, 6, 1, 12],
+                ['endComment', '*/', 1, 14],
+            ],
+            scss.tokenize(fixture('comment-with-trailing-space.scss'))
+        );
+    });
 });

--- a/test/fixture/comment-with-trailing-space.scss
+++ b/test/fixture/comment-with-trailing-space.scss
@@ -1,0 +1,1 @@
+/*my comment*/


### PR DESCRIPTION
The comment tokenizer wasn't correctly exiting in `*/` when it was
prefixed certain characters i.e. `;*/`.