### PR TITLE
Fix tokenization of unquoted imports

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -206,7 +206,6 @@ export default function tokenize(input, l, p) {
 
                 if ( code === slash && css.charCodeAt(pos + 1) !== slash ) {
                     tokens.push(['/', '/', line, pos - offset]);
-                    pos += 2;
                     break;
                 }
 

--- a/test/fixture/double-quoted-import-path.scss
+++ b/test/fixture/double-quoted-import-path.scss
@@ -1,0 +1,1 @@
+@import "foo/bar";

--- a/test/fixture/double-quoted-import.scss
+++ b/test/fixture/double-quoted-import.scss
@@ -1,0 +1,1 @@
+@import "foo";

--- a/test/fixture/single-quoted-import-path.scss
+++ b/test/fixture/single-quoted-import-path.scss
@@ -1,0 +1,1 @@
+@import 'foo/bar';

--- a/test/fixture/single-quoted-import.scss
+++ b/test/fixture/single-quoted-import.scss
@@ -1,0 +1,1 @@
+@import 'foo';

--- a/test/fixture/unquoted-import-path.scss
+++ b/test/fixture/unquoted-import-path.scss
@@ -1,0 +1,1 @@
+@import foo/bar;

--- a/test/fixture/unquoted-import.scss
+++ b/test/fixture/unquoted-import.scss
@@ -1,0 +1,1 @@
+@import foo;

--- a/test/import.js
+++ b/test/import.js
@@ -1,0 +1,106 @@
+var scss = require('..');
+var fs = require('fs');
+var path = require('path');
+var assert = require('chai').assert;
+
+var fixture = function(name) {
+    return fs.readFileSync(
+        path.join(__dirname, 'fixture', name)
+    );
+}
+
+describe('@import', function() {
+    it('should tokenize a @import with double quotes', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['"', '"', 1, 9],
+                ['string', 'foo', 1, 10, 1, 12],
+                ['"', '"', 1, 13],
+                [';', ';', 1, 14],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('double-quoted-import.scss'))
+        );
+    });
+
+    it('should tokenize a @import with single quotes', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['\'', '\'', 1, 9],
+                ['string', 'foo', 1, 10, 1, 12],
+                ['\'', '\'', 1, 13],
+                [';', ';', 1, 14],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('single-quoted-import.scss'))
+        );
+    });
+
+    it('should tokenize a @import without quotes', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['ident', 'foo', 1, 9, 1, 11],
+                [';', ';', 1, 12],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('unquoted-import.scss'))
+        );
+    });
+
+    it('should tokenize a @import with double quotes and slash', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['"', '"', 1, 9],
+                ['string', 'foo/bar', 1, 10, 1, 16],
+                ['"', '"', 1, 17],
+                [';', ';', 1, 18],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('double-quoted-import-path.scss'))
+        );
+    });
+
+    it('should tokenize a @import with single quotes and slash', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['\'', '\'', 1, 9],
+                ['string', 'foo/bar', 1, 10, 1, 16],
+                ['\'', '\'', 1, 17],
+                [';', ';', 1, 18],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('single-quoted-import-path.scss'))
+        );
+    });
+
+    it('should tokenize a @import without quotes and slash', function() {
+        assert.deepEqual(
+            [
+                ['@', '@', 1, 1],
+                ['ident', 'import', 1, 2, 1, 7],
+                ['space', ' '],
+                ['ident', 'foo', 1, 9, 1, 11],
+                ['/', '/', 1, 12],
+                ['ident', 'bar', 1, 13, 1, 15],
+                [';', ';', 1, 16],
+                ['newline', '\n', 2, 0],
+            ],
+            scss.tokenize(fixture('unquoted-import-path.scss'))
+        );
+    });
+});


### PR DESCRIPTION
Characters we're being swallowed after `/` which broken the cases
like `@import foo/bar;`. The second `ident` `bar` would be tokenized
as only `r`.