### PR TITLE
Replace babel-preset-es2015 with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    ["es2015", {"loose": true}]
+    ["env", {"node": true}]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-jest": "^22.4.3",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
     "glob": "^7.1.2",
     "jest": "^22.4.3",
     "sass-spec": "^3.5.1"


### PR DESCRIPTION
CI is failing because babel-preset-es2015 is deprecated