### PR TITLE
Fixed ReDoS in "loadAnnotation" function of "previous-map.js"

### DIFF
--- a/src/previous-map.js
+++ b/src/previous-map.js
@@ -31,7 +31,7 @@ export default class PreviousMap {
     }
 
     loadAnnotation(css) {
-        let match = css.match(/\/\*\s*# sourceMappingURL=(.*)\s*\*\//);
+        let match = css.match(/\/\*\s*# sourceMappingURL=((?:(?!sourceMappingURL=).)*)\s*\*\//);
         if ( match ) this.annotation = match[1].trim();
     }
 


### PR DESCRIPTION
- Replaced `(.*)` with `((?:(?!sourceMappingURL=).)*)` in regex used in `loadAnnotation` function of `src/previous-map.js` to fix ReDoS.

Closes #45 
Closes #48 